### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Integration Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/nicolas-graves/lfs-s3/security/code-scanning/2](https://github.com/nicolas-graves/lfs-s3/security/code-scanning/2)

To fix the issue, add an explicit `permissions:` block to the workflow file to restrict the GITHUB_TOKEN permissions to only what is necessary. Since the workflow only checks out code and runs tests, it does not need write access to anything. The minimal required permission is usually `contents: read`, which allows checkout of repository contents. The `permissions:` block should be added at the workflow level, above the `jobs:` key, to apply to all jobs, as there's no indication that any job needs more than this.

Edit `.github/workflows/test.yml`, and add the following lines after line 2 (immediately after the workflow name and before `on:`):

```yaml
permissions:
  contents: read
```

No additional libraries, modules, or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
